### PR TITLE
The modules taxonomy query should only send term id

### DIFF
--- a/includes/class-sensei-course-progress-widget.php
+++ b/includes/class-sensei-course-progress-widget.php
@@ -129,7 +129,7 @@ class Sensei_Course_Progress_Widget extends WP_Widget {
 							array(
 								'taxonomy' => Sensei()->modules->taxonomy,
 								'field' => 'id',
-								'terms' => $lesson_module
+								'terms' => intval( $lesson_module->term_id )
 							)
 						),
 						'meta_key' => '_order_module_' . intval( $lesson_module->term_id ),


### PR DESCRIPTION
This should be occurring just like it is [above](https://github.com/woocommerce/sensei-course-progress/blob/412c6e743f238966c1a1eb6226cd098bb752e3cf/includes/class-sensei-course-progress-widget.php#L105).