### PR TITLE
Fix for current lesson indicator when viewing module

### DIFF
--- a/includes/class-sensei-course-progress-widget.php
+++ b/includes/class-sensei-course-progress-widget.php
@@ -185,7 +185,7 @@ class Sensei_Course_Progress_Widget extends WP_Widget {
                 $lesson_quiz_id = absint( Sensei()->lesson->lesson_quizzes( $lesson_id ) );
 
 				// add 'current' class on the current lesson/quiz
-				if( $lesson_id === $post->ID || $lesson_quiz_id === $post->ID ) {
+				if( ! is_tax( 'module' ) && ( $lesson_id === $post->ID || $lesson_quiz_id === $post->ID ) ) {
 					$classes .= " current";
 				}
 

--- a/includes/class-sensei-course-progress-widget.php
+++ b/includes/class-sensei-course-progress-widget.php
@@ -202,7 +202,7 @@ class Sensei_Course_Progress_Widget extends WP_Widget {
 				?>
 
 				<li class="course-progress-lesson <?php echo $classes; ?>">
-					<?php if( $lesson->ID === $post->ID || $lesson_quiz_id === $post->ID ) {
+					<?php if( ! is_tax( 'module' ) && ( $lesson->ID === $post->ID || $lesson_quiz_id === $post->ID ) ) {
 						echo '<span>' . esc_html( $lesson_title ) . '</span>';
 					} else {
 						echo '<a href="' . esc_url( $lesson_url ) . '">' . esc_html( $lesson_title ) . '</a>';


### PR DESCRIPTION
The first lesson in a module has the `current` CSS class applied to it when viewing a module page. This PR removes that indicator on module pages.

## Before
![screen shot 2018-03-01 at 1 10 19 pm](https://user-images.githubusercontent.com/1190420/36861481-eccc3112-1d51-11e8-8c53-c4d8d34f5120.jpg)

## After
![screen shot 2018-03-01 at 12 13 24 pm](https://user-images.githubusercontent.com/1190420/36861231-55342274-1d51-11e8-9387-ddf4f9e188c7.jpg)

## Testing

- Add the _Course Progress Widget_ to the sidebar.
- Navigate through a course with modules. When viewing a module page, ensure that none of the lessons in the widget show as being the current lesson.
- Navigate through the lessons and ensure that the correct lesson is highlighted in the sidebar.