### PR TITLE
Automate creation of .pot file

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -5,10 +5,12 @@
 		del = require( 'del' ),
 		env = process.env.NODE_ENV || 'prod',
 		gulp = require( 'gulp' ),
+		path = require( 'path' ),
 		rename = require( 'gulp-rename' ),
 		runSequence = require( 'run-sequence' ),
 		sass = require( 'gulp-sass' ),
-		sourcemaps = require( 'gulp-sourcemaps' );
+		sourcemaps = require( 'gulp-sourcemaps' ),
+		wpi18n = require( 'node-wp-i18n' );
 
 	const paths = {
 		css: [ 'assets/css/*.scss' ]
@@ -36,7 +38,64 @@
 			.pipe( gulp.dest( 'build' ) );
 	} );
 
-	gulp.task( 'languages', function() {
+	gulp.task( 'i18n', function( cb ) {
+		var options = {
+			cwd: process.cwd(),
+			domainPath: '/languages',
+			exclude: [ 'node_modules/.*', 'build/.*' ],
+			mainFile: 'sensei-course-progress.php',
+			potComments: '',
+			potFilename: 'sensei-course-progress.pot',
+			potHeaders: {
+				poedit: true,
+				'language-team': 'LANGUAGE <EMAIL@ADDRESS>',
+				'report-msgid-bugs-to': 'https://github.com/woocommerce/sensei-course-progress/issues',
+				'x-poedit-keywordslist': true,
+			},
+			processPot: function( pot, options ) {
+				pot.headers[ 'report-msgid-bugs-to' ] = 'https://github.com/woocommerce/sensei-course-progress/issues';
+				pot.headers[ 'language-team' ] = 'LANGUAGE <EMAIL@ADDRESS>';
+
+				var translation, // Exclude meta data from pot.
+					excluded_meta = [
+						'Plugin Name of the plugin/theme',
+						'Plugin URI of the plugin/theme',
+						'Author of the plugin/theme',
+						'Author URI of the plugin/theme'
+					];
+
+				for ( translation in pot.translations[ '' ] ) {
+					if ( 'undefined' !== typeof pot.translations[ '' ][ translation ].comments.extracted ) {
+						if ( excluded_meta.indexOf( pot.translations[ '' ][ translation ].comments.extracted ) >= 0 ) {
+							console.log( 'Excluded meta: ' + pot.translations[ '' ][ translation ].comments.extracted );
+							delete pot.translations[ '' ][ translation ];
+						}
+					}
+				}
+
+				return pot;
+			},
+			type: 'wp-plugin',
+			updateTimestamp: true,
+			updatePoFiles: false
+		};
+
+		options.cwd = path.resolve( process.cwd(), options.cwd );
+		options.potFile = options.potFilename;
+
+		wpi18n.makepot( options )
+			.then( function( wpPackage ) {
+				console.log( 'POT file saved to ' + path.relative( wpPackage.getPath(), wpPackage.getPotFilename() ) );
+			})
+			.catch( function( error ) {
+				console.log( error );
+			} )
+			.finally( function() {
+				cb();
+			} );
+	} );
+
+	gulp.task( 'languages', [ 'i18n' ], function() {
 		return gulp.src( 'languages/*.*' )
 			.pipe( gulp.dest( 'build/languages' ) );
 	} );

--- a/languages/sensei-course-progress.pot
+++ b/languages/sensei-course-progress.pot
@@ -1,53 +1,62 @@
-# Copyright (C) 2015 Sensei Course Progress
+# Copyright (C) 2018 WooThemes
 # This file is distributed under the same license as the Sensei Course Progress package.
 msgid ""
 msgstr ""
-"Project-Id-Version: Sensei Course Progress 1.0.3\n"
-"Report-Msgid-Bugs-To: http://wordpress.org/tag/sensei-course-progress\n"
-"POT-Creation-Date: 2015-01-30 10:38:13+00:00\n"
+"Project-Id-Version: Sensei Course Progress 1.0.6\n"
+"Report-Msgid-Bugs-To: "
+"https://github.com/woocommerce/sensei-course-progress/issues\n"
+"POT-Creation-Date: 2018-03-08 14:31:49+00:00\n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"PO-Revision-Date: 2015-MO-DA HO:MI+ZONE\n"
+"PO-Revision-Date: 2018-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language-Team: LANGUAGE <EMAIL@ADDRESS>\n"
+"Language: en\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Poedit-Country: United States\n"
+"X-Poedit-SourceCharset: UTF-8\n"
+"X-Poedit-KeywordsList: "
+"__;_e;_x:1,2c;_ex:1,2c;_n:1,2;_nx:1,2,4c;_n_noop:1,2;_nx_noop:1,2,3c;esc_"
+"attr__;esc_html__;esc_attr_e;esc_html_e;esc_attr_x:1,2c;esc_html_x:1,2c;\n"
+"X-Poedit-Basepath: ../\n"
+"X-Poedit-SearchPath-0: .\n"
+"X-Poedit-Bookmarks: \n"
+"X-Textdomain-Support: yes\n"
 
 #: includes/class-sensei-course-progress-widget.php:28
-msgid "Displays the current learners progress within the current course/module (only displays on single lesson page)."
+msgid ""
+"Displays the current learners progress within the current course/module "
+"(only displays on single lesson page)."
 msgstr ""
 
 #: includes/class-sensei-course-progress-widget.php:30
 msgid "Sensei - Course Progress"
 msgstr ""
 
-#: includes/class-sensei-course-progress-widget.php:129
+#: includes/class-sensei-course-progress-widget.php:161
 msgid "Previous"
 msgstr ""
 
-#: includes/class-sensei-course-progress-widget.php:130
+#: includes/class-sensei-course-progress-widget.php:162
 msgid "Next"
+msgstr ""
+
+#: includes/class-sensei-course-progress-widget.php:256
+msgid "Display all Modules"
+msgstr ""
+
+#: includes/class-sensei-course-progress-widget.php:259
+msgid "There are no options for this widget."
 msgstr ""
 
 #: includes/class-sensei-course-progress.php:170
 #: includes/class-sensei-course-progress.php:179
 msgid "Cheatin&#8217; huh?"
 msgstr ""
-#. Plugin Name of the plugin/theme
-msgid "Sensei Course Progress"
-msgstr ""
-
-#. Plugin URI of the plugin/theme
-msgid "http://www.woothemes.com/"
-msgstr ""
 
 #. Description of the plugin/theme
-msgid "Sensei extension that displays the learner's progress in the current course/module in a widget on lesson pages."
-msgstr ""
-
-#. Author of the plugin/theme
-msgid "WooThemes"
-msgstr ""
-
-#. Author URI of the plugin/theme
-msgid "http://www.woothemes.com/"
+msgid ""
+"Sensei extension that displays the learner's progress in the current "
+"course/module in a widget on lesson pages."
 msgstr ""

--- a/package-lock.json
+++ b/package-lock.json
@@ -312,6 +312,12 @@
 				"inherits": "2.0.3"
 			}
 		},
+		"bluebird": {
+			"version": "3.5.1",
+			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
+			"integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA==",
+			"dev": true
+		},
 		"boom": {
 			"version": "2.10.1",
 			"resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
@@ -858,6 +864,15 @@
 				"jsbn": "0.1.1"
 			}
 		},
+		"encoding": {
+			"version": "0.1.12",
+			"resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+			"integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+			"dev": true,
+			"requires": {
+				"iconv-lite": "0.4.19"
+			}
+		},
 		"end-of-stream": {
 			"version": "0.1.5",
 			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-0.1.5.tgz",
@@ -1345,6 +1360,16 @@
 				}
 			}
 		},
+		"gettext-parser": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/gettext-parser/-/gettext-parser-1.3.1.tgz",
+			"integrity": "sha512-W4t55eB/c7WrH0gbCHFiHuaEnJ1WiPJVnbFFiNEoh2QkOmuSLxs0PmJDGAmCQuTJCU740Fmb6D+2D/2xECWZGQ==",
+			"dev": true,
+			"requires": {
+				"encoding": "0.1.12",
+				"safe-buffer": "5.1.1"
+			}
+		},
 		"glob": {
 			"version": "7.1.2",
 			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
@@ -1784,6 +1809,12 @@
 				"jsprim": "1.4.1",
 				"sshpk": "1.13.1"
 			}
+		},
+		"iconv-lite": {
+			"version": "0.4.19",
+			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
+			"integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ==",
+			"dev": true
 		},
 		"in-publish": {
 			"version": "2.0.0",
@@ -2688,6 +2719,29 @@
 						"minimatch": "3.0.4"
 					}
 				},
+				"lodash": {
+					"version": "4.17.5",
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
+					"integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw==",
+					"dev": true
+				}
+			}
+		},
+		"node-wp-i18n": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/node-wp-i18n/-/node-wp-i18n-1.0.5.tgz",
+			"integrity": "sha512-IqU2IR5XEptL3e+m4nxlKStS71Vcxe1lEQq8d33ou6T0c0JmoLk8rexs2ur6PBjJWGN5dhSG6y0NWMAS64C4mw==",
+			"dev": true,
+			"requires": {
+				"bluebird": "3.5.1",
+				"gettext-parser": "1.3.1",
+				"glob": "7.1.2",
+				"lodash": "4.17.5",
+				"minimist": "1.2.0",
+				"mkdirp": "0.5.1",
+				"tmp": "0.0.33"
+			},
+			"dependencies": {
 				"lodash": {
 					"version": "4.17.5",
 					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
@@ -3943,6 +3997,15 @@
 			"requires": {
 				"es5-ext": "0.10.39",
 				"next-tick": "1.0.0"
+			}
+		},
+		"tmp": {
+			"version": "0.0.33",
+			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+			"integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+			"dev": true,
+			"requires": {
+				"os-tmpdir": "1.0.2"
 			}
 		},
 		"to-object-path": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
 		"gulp-rename": "^1.2.2",
 		"gulp-sass": "^3.1.0",
 		"gulp-sourcemaps": "^2.6.4",
+		"node-wp-i18n": "^1.0.5",
 		"run-sequence": "^2.2.1"
 	}
 }


### PR DESCRIPTION
Adds a `gulp i18n` task that recreates the `languages/sensei-course-progress.pot` file. Note that the generated POT file will exclude plugin name, plugin URI, author and author URI.

Although there is a `gulp-wp-pot` package to create POT files, I found it didn't translate text like the plugin description and didn't output common headers. I opted to use `node-wp-i18n` instead, which `grunt-wp-i18n` uses under the hood, to get better and consistent results. There's an opportunity here to create a a `gulp-wp-i18n` package to make this easier in the future, but that's a task best left for another day. 😄 

## Testing
- Delete the `languages` folder.
- Run `gulp` and ensure the `languages` folder is recreated and contains `sensei-course-progress.pot`.
- Check that the `languages` folder is copied to `build/`.