### PR TITLE
Don't regenerate .pot file for development tasks

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -110,7 +110,7 @@
 	} );
 
 	gulp.task( 'build-dev', function ( cb ) {
-		runSequence( 'clean', [ 'css', 'php', 'languages' ], [ 'watch' ], cb );
+		runSequence( 'clean', [ 'css', 'php' ], [ 'watch' ], cb );
 	});
 
 	gulp.task( 'default', function( cb ) {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -103,7 +103,6 @@
 	gulp.task( 'watch', function() {
 		gulp.watch( paths.css, [ 'css' ]);
 		gulp.watch( [ '**/*.php', '!node_modules/**', '!build/**' ], [ 'php' ]);
-		gulp.watch( 'languages/*.*', [ 'languages' ]);
 	} );
 
 	gulp.task( 'build', function ( cb ) {


### PR DESCRIPTION
This PR changes the build so that the `.pot` file is not regenerated when the `watch` or `build-dev` Gulp tasks are run.