### PR TITLE
Fix widget for lessons with no module

### DIFF
--- a/includes/class-sensei-course-progress-widget.php
+++ b/includes/class-sensei-course-progress-widget.php
@@ -140,7 +140,6 @@ class Sensei_Course_Progress_Widget extends WP_Widget {
 				} else {
 					// Only display current module
 			    	// get all lessons in the current module
-					// TODO: tweak this for Other Lessons
 					$args = array(
 						'post_type' => 'lesson',
 						'post_status' => 'publish',
@@ -152,17 +151,30 @@ class Sensei_Course_Progress_Widget extends WP_Widget {
 								'compare' => '='
 							)
 						),
-						'tax_query' => array(
+					);
+
+					if ( $lesson_module ) {
+						$args['tax_query'] = array(
 							array(
 								'taxonomy' => Sensei()->modules->taxonomy,
-								'field' => 'id',
-								'terms' => intval( $lesson_module->term_id )
-							)
-						),
-						'meta_key' => '_order_module_' . absint( $lesson_module->term_id ),
-						'orderby' => 'meta_value_num date',
-						'order' => 'ASC'
-					);
+								'field'    => 'id',
+								'terms'    => intval( $lesson_module->term_id ),
+							),
+						);
+						$args['meta_key']  = '_order_module_' . absint( $lesson_module->term_id );
+						$args['orderby']   = 'meta_value_num date';
+						$args['order']     = 'ASC';
+					} else {
+						$args['tax_query'] = array(
+							array(
+								'taxonomy' => Sensei()->modules->taxonomy,
+								'operator' => 'NOT EXISTS',
+							),
+						);
+						$args['meta_key']  = '_order_' . absint( $lesson_course_id );
+						$args['orderby']   = 'meta_value_num date';
+						$args['order']     = 'ASC';
+					}
 
 					$lesson_array = get_posts( $args );
 				}

--- a/includes/class-sensei-course-progress-widget.php
+++ b/includes/class-sensei-course-progress-widget.php
@@ -85,6 +85,12 @@ class Sensei_Course_Progress_Widget extends WP_Widget {
 				$lesson_module = Sensei()->modules->get_lesson_module( $current_lesson_id );
 				$in_module = true;
 
+				// Get an array of module ids.
+				$course_module_ids = array();
+				foreach ( $course_modules as $module ) {
+					$course_module_ids[] = $module->term_id;
+				}
+
 				// Display all modules
 				if ( 'on' === $allmodules ) {
 					foreach ($course_modules as $module) {
@@ -114,7 +120,8 @@ class Sensei_Course_Progress_Widget extends WP_Widget {
 						$lesson_array = array_merge( $lesson_array, get_posts( $args) );
 					}
 
-					// Get all lessons in the course that are not in a module.
+					// Get all lessons in the course that are not in any of the
+					// course's modules.
 					$args = array(
 						'post_type' => 'lesson',
 						'post_status' => 'publish',
@@ -129,7 +136,9 @@ class Sensei_Course_Progress_Widget extends WP_Widget {
 						'tax_query' => array(
 							array(
 								'taxonomy' => Sensei()->modules->taxonomy,
-								'operator' => 'NOT EXISTS',
+								'field'    => 'id',
+								'terms'    => $course_module_ids,
+								'operator' => 'NOT IN',
 							)
 						),
 						'meta_key' => '_order_' . intval( $lesson_course_id ),
@@ -153,7 +162,7 @@ class Sensei_Course_Progress_Widget extends WP_Widget {
 						),
 					);
 
-					if ( $lesson_module ) {
+					if ( in_array( $lesson_module->term_id, $course_module_ids ) ) {
 						$args['tax_query'] = array(
 							array(
 								'taxonomy' => Sensei()->modules->taxonomy,
@@ -168,7 +177,9 @@ class Sensei_Course_Progress_Widget extends WP_Widget {
 						$args['tax_query'] = array(
 							array(
 								'taxonomy' => Sensei()->modules->taxonomy,
-								'operator' => 'NOT EXISTS',
+								'field'    => 'id',
+								'terms'    => $course_module_ids,
+								'operator' => 'NOT IN',
 							),
 						);
 						$args['meta_key']  = '_order_' . absint( $lesson_course_id );


### PR DESCRIPTION
Fixes #43 

For courses with modules, this fixes the widget when there are also lessons with no module. They are displayed at the bottom under the heading "Other Lessons".

## Testing Instructions

- Create a course, add some lessons, add some modules, and add some of the lessons to some of the modules.

- Ensure that there are a few lessons that are not in a module.

- Set up the Course Progress widget and ensure the "Display all Modules" checkbox is checked.

- Inspect the widget on the frontend by viewing a lesson. Ensure that the lessons without modules are displayed as described above.

- Uncheck the "Display all Modules" checkbox and save the widget. When visiting the various lessons in the course, ensure that widget correctly displays the lessons that are in the current lesson's module. If the current lesson does not have a module, the widget should display all the lessons that do not have a module.

- Try with a course that has no modules. All lessons should be displayed in the widget.

- In each scenario above, go to the Order Lessons page and reorder the lessons without modules. Their display in the widget should respect that ordering.

- In each scenario above, try removing a module from the course. Ensure that the lessons from that module are displayed in Other Lessons. (See https://github.com/woocommerce/sensei-course-progress/pull/50#issuecomment-384603952)

- Note that when only lessons without a module are shown, the "Other Lessons" section title is omitted.