### PR TITLE
Fix PHP notices

### DIFF
--- a/includes/class-sensei-course-progress-widget.php
+++ b/includes/class-sensei-course-progress-widget.php
@@ -162,7 +162,7 @@ class Sensei_Course_Progress_Widget extends WP_Widget {
 						),
 					);
 
-					if ( in_array( $lesson_module->term_id, $course_module_ids ) ) {
+					if ( isset( $lesson_module ) && in_array( $lesson_module->term_id, $course_module_ids ) ) {
 						$args['tax_query'] = array(
 							array(
 								'taxonomy' => Sensei()->modules->taxonomy,

--- a/includes/class-sensei-course-progress-widget.php
+++ b/includes/class-sensei-course-progress-widget.php
@@ -285,7 +285,7 @@ class Sensei_Course_Progress_Widget extends WP_Widget {
 		$instance = $old_instance;
 
 		/* The check box is returning a boolean value. */
-		$instance['allmodules'] = esc_html( $new_instance['allmodules'] );
+		$instance['allmodules'] = isset( $new_instance['allmodules'] ) ? esc_html( $new_instance['allmodules'] ) : '';
 
 		return $instance;
 	} // End update()

--- a/includes/class-sensei-course-progress-widget.php
+++ b/includes/class-sensei-course-progress-widget.php
@@ -162,7 +162,7 @@ class Sensei_Course_Progress_Widget extends WP_Widget {
 						),
 					);
 
-					if ( isset( $lesson_module ) && in_array( $lesson_module->term_id, $course_module_ids ) ) {
+					if ( ! empty( $lesson_module ) && in_array( $lesson_module->term_id, $course_module_ids ) ) {
 						$args['tax_query'] = array(
 							array(
 								'taxonomy' => Sensei()->modules->taxonomy,


### PR DESCRIPTION
This PR addresses a couple of PHP notices generated by the widget:
```
PHP Notice:  Undefined index: allmodules in /app/public/wp-content/plugins/sensei-course-progress/includes/class-sensei-course-progress-widget.php on line 289
PHP Notice:  Trying to get property of non-object in /app/public/wp-content/plugins/sensei-course-progress/includes/class-sensei-course-progress-widget.php on line 168
```

## Testing
_Saving_
1. Add the _Course Progress_ widget to a widget area. Select _Display all Modules_ and save.
2. Unselect _Display all Modules_ and save again.
3. Ensure that the setting is saved and that the following PHP notice is not logged:
```
PHP Notice:  Undefined index: allmodules in /app/public/wp-content/plugins/sensei-course-progress/includes/class-sensei-course-progress-widget.php on line 289
```

_Viewing_
1. Ensure _Display all Modules_ is unchecked.
2. Browse to a page containing the widget.
3. Ensure the following PHP notice is not logged:
```
PHP Notice:  Trying to get property of non-object in /app/public/wp-content/plugins/sensei-course-progress/includes/class-sensei-course-progress-widget.php on line 168
```