### PR TITLE
Address violations reported by PHPCS

### DIFF
--- a/includes/class-sensei-course-progress-widget.php
+++ b/includes/class-sensei-course-progress-widget.php
@@ -195,7 +195,7 @@ class Sensei_Course_Progress_Widget extends WP_Widget {
 			}
 		}
 
-		echo $before_widget; // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
+		echo wp_kses_post( $before_widget );
     ?>
 
 		<header>
@@ -254,7 +254,7 @@ class Sensei_Course_Progress_Widget extends WP_Widget {
 						?>
 						<li class="course-progress-module">
 							<h3 class="module-title">
-								<?php echo $module_title; // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped ?>
+								<?php echo wp_kses_post( $module_title ); ?>
 							</h3>
 						</li>
 						<?php
@@ -276,7 +276,7 @@ class Sensei_Course_Progress_Widget extends WP_Widget {
 
 		</ul>
 
-		<?php echo $after_widget; // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
+		<?php echo wp_kses_post( $after_widget );
 	}
 
 	/**

--- a/includes/class-sensei-course-progress-widget.php
+++ b/includes/class-sensei-course-progress-widget.php
@@ -195,7 +195,8 @@ class Sensei_Course_Progress_Widget extends WP_Widget {
 			}
 		}
 
-		echo $before_widget; ?>
+		echo $before_widget; // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
+    ?>
 
 		<header>
 			<h2 class="course-title"><a href="<?php echo esc_url( $course_url ); ?>"><?php echo esc_html( $course_title ); ?></a></h2>
@@ -206,8 +207,8 @@ class Sensei_Course_Progress_Widget extends WP_Widget {
 		if ( isset( $nav_array['previous'] ) || isset( $nav_array['next'] ) ) { ?>
 
 			<ul class="course-progress-navigation">
-				<?php if ( isset( $nav_array['previous'] ) ) { ?><li class="prev"><a href="<?php echo esc_url( $nav_array['previous']['url'] ); ?>" title="<?php echo $nav_array['previous']['name']; ?>"><span><?php esc_html_e( 'Previous', 'sensei-course-progress' ); ?></span></a></li><?php } ?>
-				<?php if ( isset( $nav_array['next'] ) ) { ?><li class="next"><a href="<?php echo esc_url( $nav_array['next']['url'] ); ?>" title="<?php echo $nav_array['next']['name']; ?>"><span><?php esc_html_e( 'Next', 'sensei-course-progress' ); ?></span></a></li><?php } ?>
+				<?php if ( isset( $nav_array['previous'] ) ) { ?><li class="prev"><a href="<?php echo esc_url( $nav_array['previous']['url'] ); ?>" title="<?php echo esc_attr( $nav_array['previous']['name'] ); ?>"><span><?php esc_html_e( 'Previous', 'sensei-course-progress' ); ?></span></a></li><?php } ?>
+				<?php if ( isset( $nav_array['next'] ) ) { ?><li class="next"><a href="<?php echo esc_url( $nav_array['next']['url'] ); ?>" title="<?php echo esc_attr( $nav_array['next']['name'] ); ?>"><span><?php esc_html_e( 'Next', 'sensei-course-progress' ); ?></span></a></li><?php } ?>
 			</ul>
 
 		<?php } ?>
@@ -251,7 +252,11 @@ class Sensei_Course_Progress_Widget extends WP_Widget {
 						}
 
 						?>
-						<li class="course-progress-module"><h3 class="module-title"><?php echo $module_title; ?></h3></li>
+						<li class="course-progress-module">
+							<h3 class="module-title">
+								<?php echo $module_title; // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped ?>
+							</h3>
+						</li>
 						<?php
 						$old_module = $new_module;
 					}
@@ -259,7 +264,7 @@ class Sensei_Course_Progress_Widget extends WP_Widget {
 
 				?>
 
-				<li class="course-progress-lesson <?php echo $classes; ?>">
+				<li class="course-progress-lesson <?php echo esc_attr( $classes ); ?>">
 					<?php if( ! is_tax( 'module' ) && ( $lesson->ID === $post->ID || $lesson_quiz_id === $post->ID ) ) {
 						echo '<span>' . esc_html( $lesson_title ) . '</span>';
 					} else {
@@ -271,7 +276,7 @@ class Sensei_Course_Progress_Widget extends WP_Widget {
 
 		</ul>
 
-		<?php echo $after_widget;
+		<?php echo $after_widget; // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
 	}
 
 	/**
@@ -332,7 +337,7 @@ class Sensei_Course_Progress_Widget extends WP_Widget {
 		}
 
 		if ( $link_to_module ) {
-			return '<a href="' . $module->url . '">' . esc_html( $module->name ) . '</a>';
+			return '<a href="' . esc_url( $module->url ) . '">' . esc_html( $module->name ) . '</a>';
 		}
 
 		return esc_html( $module->name );

--- a/includes/class-sensei-course-progress.php
+++ b/includes/class-sensei-course-progress.php
@@ -167,7 +167,7 @@ class Sensei_Course_Progress {
 	 * @since 1.0.0
 	 */
 	public function __clone () {
-		_doing_it_wrong( __FUNCTION__, esc_html__( 'Cheatin&#8217; huh?' ), esc_html( $this->_version ) );
+		_doing_it_wrong( __FUNCTION__, esc_html__( 'Cheatin&#8217; huh?', 'sensei-course-progress' ), esc_html( $this->_version ) );
 	} // End __clone()
 
 	/**
@@ -176,7 +176,7 @@ class Sensei_Course_Progress {
 	 * @since 1.0.0
 	 */
 	public function __wakeup () {
-		_doing_it_wrong( __FUNCTION__, esc_html__( 'Cheatin&#8217; huh?' ), esc_html( $this->_version ) );
+		_doing_it_wrong( __FUNCTION__, esc_html__( 'Cheatin&#8217; huh?', 'sensei-course-progress' ), esc_html( $this->_version ) );
 	} // End __wakeup()
 
 	/**

--- a/includes/class-sensei-course-progress.php
+++ b/includes/class-sensei-course-progress.php
@@ -167,7 +167,7 @@ class Sensei_Course_Progress {
 	 * @since 1.0.0
 	 */
 	public function __clone () {
-		_doing_it_wrong( __FUNCTION__, __( 'Cheatin&#8217; huh?' ), $this->_version );
+		_doing_it_wrong( __FUNCTION__, esc_html__( 'Cheatin&#8217; huh?' ), esc_html( $this->_version ) );
 	} // End __clone()
 
 	/**
@@ -176,7 +176,7 @@ class Sensei_Course_Progress {
 	 * @since 1.0.0
 	 */
 	public function __wakeup () {
-		_doing_it_wrong( __FUNCTION__, __( 'Cheatin&#8217; huh?' ), $this->_version );
+		_doing_it_wrong( __FUNCTION__, esc_html__( 'Cheatin&#8217; huh?' ), esc_html( $this->_version ) );
 	} // End __wakeup()
 
 	/**

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -9,6 +9,7 @@
 	<file>.</file>
 	<!-- Ignoring Files and Folders:
 		https://github.com/squizlabs/PHP_CodeSniffer/wiki/Advanced-Usage#ignoring-files-and-folders -->
+	<exclude-pattern>./build/</exclude-pattern>
 	<exclude-pattern>./node_modules/</exclude-pattern>
 	<exclude-pattern>./vendor/</exclude-pattern>
 

--- a/woo-includes/woo-functions.php
+++ b/woo-includes/woo-functions.php
@@ -74,16 +74,21 @@ if ( ! class_exists( 'WooThemes_Updater' ) && ! function_exists( 'woothemes_upda
         $install_url = wp_nonce_url( self_admin_url( 'update.php?action=install-plugin&plugin=' . $slug ), 'install-plugin_' . $slug );
         $activate_url = 'plugins.php?action=activate&plugin=' . urlencode( 'woothemes-updater/woothemes-updater.php' ) . '&plugin_status=all&paged=1&s&_wpnonce=' . urlencode( wp_create_nonce( 'activate-plugin_woothemes-updater/woothemes-updater.php' ) );
 
-        $message = '<a href="' . esc_url( $install_url ) . '">Install the WooThemes Updater plugin</a> to get updates for your WooThemes plugins.';
+        $message_url = $install_url;
+        $message_text = 'Install';
         $is_downloaded = false;
         $plugins = array_keys( get_plugins() );
+
         foreach ( $plugins as $plugin ) {
             if ( strpos( $plugin, 'woothemes-updater.php' ) !== false ) {
                 $is_downloaded = true;
-                $message = '<a href="' . esc_url( admin_url( $activate_url ) ) . '">Activate the WooThemes Updater plugin</a> to get updates for your WooThemes plugins.';
+                $message_url = admin_url( $activate_url );
+                $message_text = 'Activate';
             }
         }
-        echo '<div class="updated fade"><p>' . $message . '</p></div>' . "\n";
+
+        echo '<div class="updated fade"><p><a href="' . esc_url( $message_url ) . '">' .
+          esc_html( $message_text ) . ' the WooThemes Updater plugin</a> to receive updates for Sensei Course Progress.</p></div>' . "\n";
     }
 
     add_action( 'admin_notices', 'woothemes_updater_notice' );


### PR DESCRIPTION
This PR fixes some of the violations reported by PHPCS.

## Testing
1. Activate Sensei and this branch of Sensei Course Progress.
2. Add the Sensei - Course Progress widget to the sidebar.
3. Ensure the widget shows correctly on the module and lesson pages.
4. Navigate between modules and lessons using the course progress widget. Test with modules that have content (i.e. should render as links) and modules without any content (i.e. should render as text).
5. Check the _Display all Modules_ in the widget and repeat steps 3 and 4.
6. Deactivate WooCommerce and uninstall the WooCommerce Helper plugin, if applicable.
7. Ensure that you see the following notice:
![screen shot 2018-10-16 at 1 58 35 pm](https://user-images.githubusercontent.com/1190420/47036932-98234200-d14b-11e8-9e57-4086e7fa67b3.jpg)
8. Click on the link and check that the WooCommerce Helper plugin is installed.
9. Ensure that you see the following notice:
![screen shot 2018-10-16 at 1 59 21 pm](https://user-images.githubusercontent.com/1190420/47036969-b5f0a700-d14b-11e8-8de7-9d8699b16ac9.jpg)
10. Click on the link and check that the WooCommerce Helper plugin is activated.