### PR TITLE
Load most of plugin and check dependencies after other plugins have loaded

### DIFF
--- a/includes/class-sensei-course-progress-dependency-checker.php
+++ b/includes/class-sensei-course-progress-dependency-checker.php
@@ -13,21 +13,41 @@ class Sensei_Course_Progress_Dependency_Checker {
 	const MINIMUM_SENSEI_VERSION = '1.11.0';
 
 	/**
-	 * Checks if all dependencies are met.
+	 * Checks if all system dependencies are met.
 	 *
 	 * @return bool
 	 */
-	public static function are_dependencies_met() {
+	public static function are_system_dependencies_met() {
 		$are_met = true;
 		if ( ! self::check_php() ) {
 			add_action( 'admin_notices', array( __CLASS__, 'add_php_notice' ) );
 			$are_met = false;
 		}
+		if ( ! $are_met ) {
+			add_action( 'admin_init', array( __CLASS__, 'deactivate_self' ) );
+		}
+		return $are_met;
+	}
+
+	/**
+	 * Checks if all plugin dependencies are met.
+	 *
+	 * @return bool
+	 */
+	public static function are_plugin_dependencies_met() {
+		$are_met = true;
 		if ( ! self::check_sensei() ) {
 			add_action( 'admin_notices', array( __CLASS__, 'add_sensei_notice' ) );
 			$are_met = false;
 		}
 		return $are_met;
+	}
+
+	/**
+	 * Deactivate self.
+	 */
+	public static function deactivate_self() {
+		deactivate_plugins( SENSEI_COURSE_PROGRESS_PLUGIN_BASENAME );
 	}
 
 	/**

--- a/includes/class-sensei-course-progress-dependency-checker.php
+++ b/includes/class-sensei-course-progress-dependency-checker.php
@@ -13,29 +13,6 @@ class Sensei_Course_Progress_Dependency_Checker {
 	const MINIMUM_SENSEI_VERSION = '1.11.0';
 
 	/**
-	 * The list of active plugins.
-	 *
-	 * @var array
-	 */
-	private static $active_plugins;
-
-	/**
-	 * Get active plugins.
-	 *
-	 * @return string[]
-	 */
-	private static function get_active_plugins() {
-		if ( ! isset( self::$active_plugins ) ) {
-			self::$active_plugins = (array) get_option( 'active_plugins', array() );
-
-			if ( is_multisite() ) {
-				self::$active_plugins = array_merge( self::$active_plugins, get_site_option( 'active_sitewide_plugins', array() ) );
-			}
-		}
-		return self::$active_plugins;
-	}
-
-	/**
 	 * Checks if all dependencies are met.
 	 *
 	 * @return bool
@@ -68,23 +45,7 @@ class Sensei_Course_Progress_Dependency_Checker {
 	 * @return bool
 	 */
 	private static function check_sensei() {
-		$active_plugins = self::get_active_plugins();
-
-		$search_sensei = array(
-			'sensei/sensei.php',                     // Sensei 2.x from WordPress.org.
-			'sensei/woothemes-sensei.php',           // Sensei 1.x or Sensei 2.x Compatibility Plugin.
-			'woothemes-sensei/woothemes-sensei.php', // Sensei 1.x or Sensei 2.x Compatibility Plugin.
-		);
-
-		$found_sensei = false;
-		foreach ( $search_sensei as $basename ) {
-			if ( in_array( $basename, $active_plugins, true ) || array_key_exists( $basename, $active_plugins ) ) {
-				$found_sensei = true;
-				break;
-			}
-		}
-
-		if ( ! $found_sensei && ! class_exists( 'Sensei_Main' ) ) {
+		if ( ! class_exists( 'Sensei_Main' ) ) {
 			return false;
 		}
 

--- a/includes/class-sensei-course-progress-dependency-checker.php
+++ b/includes/class-sensei-course-progress-dependency-checker.php
@@ -88,7 +88,7 @@ class Sensei_Course_Progress_Dependency_Checker {
 		}
 
 		// translators: %1$s is version of PHP that this plugin requires; %2$s is the version of PHP WordPress is running on.
-		$message = sprintf( __( '<strong>Sensei Course Progress</strong> requires PHP version %1$s but you are running %2$s.', 'sensei-course-progress' ), self::MINIMUM_PHP_VERSION, phpversion() );
+		$message = sprintf( __( '<strong>Sensei Course Progress</strong> requires a minimum PHP version of %1$s, but you are running %2$s.', 'sensei-course-progress' ), self::MINIMUM_PHP_VERSION, phpversion() );
 		echo '<div class="error"><p>';
 		echo wp_kses( $message, array( 'strong' => array() ) );
 		$php_update_url = 'https://wordpress.org/support/update-php/';

--- a/includes/class-sensei-course-progress.php
+++ b/includes/class-sensei-course-progress.php
@@ -93,7 +93,7 @@ class Sensei_Course_Progress {
 			return Sensei_Course_Progress::instance();
 		}
 
-		$instance = Sensei_Course_Progress();
+		$instance = Sensei_Course_Progress::instance();
 
 		// Load frontend CSS.
 		add_action( 'wp_enqueue_scripts', array( $instance, 'enqueue_styles' ), 10 );

--- a/includes/class-sensei-course-progress.php
+++ b/includes/class-sensei-course-progress.php
@@ -71,14 +71,15 @@ class Sensei_Course_Progress {
 
 		// Handle localisation.
 		$this->load_plugin_textdomain();
-
-		add_action( 'init', array( $this, 'load_localisation' ), 0 );
 	} // End __construct()
 
 	/**
 	 * Set up all hooks and filters if dependencies are met.
 	 */
 	public static function init() {
+		$instance = self::instance();
+		add_action( 'init', array( $instance, 'load_localisation' ), 0 );
+
 		if ( ! Sensei_Course_Progress_Dependency_Checker::are_plugin_dependencies_met() ) {
 			return;
 		}
@@ -92,8 +93,6 @@ class Sensei_Course_Progress {
 		function Sensei_Course_Progress() {
 			return Sensei_Course_Progress::instance();
 		}
-
-		$instance = self::instance();
 
 		// Load frontend CSS.
 		add_action( 'wp_enqueue_scripts', array( $instance, 'enqueue_styles' ), 10 );

--- a/includes/class-sensei-course-progress.php
+++ b/includes/class-sensei-course-progress.php
@@ -69,17 +69,38 @@ class Sensei_Course_Progress {
 
 		register_activation_hook( SENSEI_COURSE_PROGRESS_PLUGIN_FILE, array( $this, 'install' ) );
 
-		// Load frontend CSS.
-		add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_styles' ), 10 );
-
 		// Handle localisation.
-		$this->load_plugin_textdomain ();
+		$this->load_plugin_textdomain();
+
 		add_action( 'init', array( $this, 'load_localisation' ), 0 );
+	} // End __construct()
+
+	/**
+	 * Set up all hooks and filters if dependencies are met.
+	 */
+	public static function init() {
+		if ( ! Sensei_Course_Progress_Dependency_Checker::are_plugin_dependencies_met() ) {
+			return;
+		}
+
+		/**
+		 * Returns the main instance of Sensei_Course_Progress to prevent the need to use globals.
+		 *
+		 * @since  1.0.0
+		 * @return Sensei_Course_Progress
+		 */
+		function Sensei_Course_Progress() {
+			return Sensei_Course_Progress::instance();
+		}
+
+		$instance = Sensei_Course_Progress();
+
+		// Load frontend CSS.
+		add_action( 'wp_enqueue_scripts', array( $instance, 'enqueue_styles' ), 10 );
 
 		// Include Widget.
-		add_action( 'widgets_init', array( $this, 'include_widgets' ) );
-
-	} // End __construct()
+		add_action( 'widgets_init', array( $instance, 'include_widgets' ) );
+	}
 
 	/**
 	 * Include widgets

--- a/includes/class-sensei-course-progress.php
+++ b/includes/class-sensei-course-progress.php
@@ -67,10 +67,9 @@ class Sensei_Course_Progress {
 
 		$this->script_suffix = defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ? '' : '.min';
 
-		register_activation_hook( SENSEI_COURSE_PROGRESS_PLUGIN_FILE, array( $this, 'install' ) );
-
-		// Handle localisation.
 		$this->load_plugin_textdomain();
+
+		register_activation_hook( SENSEI_COURSE_PROGRESS_PLUGIN_FILE, array( $this, 'install' ) );
 	} // End __construct()
 
 	/**

--- a/includes/class-sensei-course-progress.php
+++ b/includes/class-sensei-course-progress.php
@@ -93,7 +93,7 @@ class Sensei_Course_Progress {
 			return Sensei_Course_Progress::instance();
 		}
 
-		$instance = Sensei_Course_Progress::instance();
+		$instance = self::instance();
 
 		// Load frontend CSS.
 		add_action( 'wp_enqueue_scripts', array( $instance, 'enqueue_styles' ), 10 );

--- a/includes/class-sensei-course-progress.php
+++ b/includes/class-sensei-course-progress.php
@@ -29,22 +29,6 @@ class Sensei_Course_Progress {
 	private $_token;
 
 	/**
-	 * The main plugin file.
-	 * @var     string
-	 * @access  private
-	 * @since   1.0.0
-	 */
-	private $file;
-
-	/**
-	 * The main plugin directory.
-	 * @var     string
-	 * @access  private
-	 * @since   1.0.0
-	 */
-	private $dir;
-
-	/**
 	 * The plugin assets directory.
 	 * @var     string
 	 * @access  private
@@ -74,27 +58,25 @@ class Sensei_Course_Progress {
 	 * @since   1.0.0
 	 * @return  void
 	 */
-	public function __construct ( $file, $version = '1.0.0' ) {
-		$this->_version = $version;
-		$this->_token = 'sensei_course_progress';
+	public function __construct() {
+		$this->_version = SENSEI_COURSE_PROGRESS_VERSION;
+		$this->_token   = 'sensei_course_progress';
 
-		$this->file = $file;
-		$this->dir = dirname( $this->file );
-		$this->assets_dir = trailingslashit( $this->dir ) . 'assets';
-		$this->assets_url = esc_url( trailingslashit( plugins_url( '/assets/', $this->file ) ) );
+		$this->assets_dir = trailingslashit( dirname( SENSEI_COURSE_PROGRESS_PLUGIN_FILE ) ) . 'assets';
+		$this->assets_url = esc_url( trailingslashit( plugins_url( '/assets/', SENSEI_COURSE_PROGRESS_PLUGIN_FILE ) ) );
 
 		$this->script_suffix = defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ? '' : '.min';
 
-		register_activation_hook( $this->file, array( $this, 'install' ) );
+		register_activation_hook( SENSEI_COURSE_PROGRESS_PLUGIN_FILE, array( $this, 'install' ) );
 
-		// Load frontend CSS
+		// Load frontend CSS.
 		add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_styles' ), 10 );
 
-		// Handle localisation
+		// Handle localisation.
 		$this->load_plugin_textdomain ();
 		add_action( 'init', array( $this, 'load_localisation' ), 0 );
 
-		// Include Widget
+		// Include Widget.
 		add_action( 'widgets_init', array( $this, 'include_widgets' ) );
 
 	} // End __construct()
@@ -103,7 +85,7 @@ class Sensei_Course_Progress {
 	 * Include widgets
 	 */
 	public function include_widgets() {
-		include_once( dirname( __FILE__ ) . '/class-sensei-course-progress-widget.php' );
+		include_once dirname( __FILE__ ) . '/class-sensei-course-progress-widget.php';
 		register_widget( 'Sensei_Course_Progress_Widget' );
 	}
 
@@ -114,8 +96,6 @@ class Sensei_Course_Progress {
 	 * @return void
 	 */
 	public function enqueue_styles () {
-		global $woothemes_sensei;
-
 		wp_register_style( $this->_token . '-frontend', esc_url( $this->assets_url ) . 'css/frontend.min.css', array(), $this->_version );
 		wp_enqueue_style( $this->_token . '-frontend' );
 	} // End enqueue_styles()
@@ -127,7 +107,7 @@ class Sensei_Course_Progress {
 	 * @return void
 	 */
 	public function load_localisation () {
-		load_plugin_textdomain( 'sensei-course-progress' , false , dirname( plugin_basename( $this->file ) ) . '/lang/' );
+		load_plugin_textdomain( 'sensei-course-progress' , false , dirname( SENSEI_COURSE_PROGRESS_PLUGIN_BASENAME ) . '/lang/' );
 	} // End load_localisation()
 
 	/**
@@ -137,12 +117,12 @@ class Sensei_Course_Progress {
 	 * @return void
 	 */
 	public function load_plugin_textdomain () {
-	    $domain = 'sensei-course-progress';
+		$domain = 'sensei-course-progress';
 
-	    $locale = apply_filters( 'plugin_locale' , get_locale() , $domain );
+		$locale = apply_filters( 'plugin_locale' , get_locale() , $domain );
 
-	    load_textdomain( $domain , WP_LANG_DIR . '/' . $domain . '/' . $domain . '-' . $locale . '.mo' );
-	    load_plugin_textdomain( $domain , FALSE , dirname( plugin_basename( $this->file ) ) . '/lang/' );
+		load_textdomain( $domain , WP_LANG_DIR . '/' . $domain . '/' . $domain . '-' . $locale . '.mo' );
+		load_plugin_textdomain( $domain , FALSE , dirname( SENSEI_COURSE_PROGRESS_PLUGIN_BASENAME ) . '/lang/' );
 	} // End load_plugin_textdomain
 
 	/**
@@ -153,11 +133,12 @@ class Sensei_Course_Progress {
 	 * @since 1.0.0
 	 * @static
 	 * @see Sensei_Course_Progress()
-	 * @return Main Sensei_Course_Progress instance
+	 * @return Sensei_Course_Progress instance
 	 */
-	public static function instance ( $file, $version = '1.0.0' ) {
-		if ( is_null( self::$_instance ) )
-			self::$_instance = new self( $file, $version );
+	public static function instance() {
+		if ( is_null( self::$_instance ) ) {
+			self::$_instance = new self();
+		}
 		return self::$_instance;
 	} // End instance()
 

--- a/sensei-course-progress.php
+++ b/sensei-course-progress.php
@@ -17,6 +17,10 @@
 
 if ( ! defined( 'ABSPATH' ) ) exit;
 
+define( 'SENSEI_COURSE_PROGRESS_VERSION', '2.0.0-beta.1' );
+define( 'SENSEI_COURSE_PROGRESS_PLUGIN_FILE', __FILE__ );
+define( 'SENSEI_COURSE_PROGRESS_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );
+
 require_once dirname( __FILE__ ) . '/includes/class-sensei-course-progress-dependency-checker.php';
 
 if ( ! Sensei_Course_Progress_Dependency_Checker::are_dependencies_met() ) {
@@ -32,7 +36,7 @@ require_once( dirname( __FILE__ ) . '/includes/class-sensei-course-progress.php'
  * @return object Sensei_Course_Progress
  */
 function Sensei_Course_Progress() {
-	return Sensei_Course_Progress::instance( __FILE__, '2.0.0-beta.1' );
+	return Sensei_Course_Progress::instance();
 }
 
 Sensei_Course_Progress();

--- a/sensei-course-progress.php
+++ b/sensei-course-progress.php
@@ -7,6 +7,7 @@
  * Author: Automattic
  * Author URI: https://automattic.com
  * Requires at least: 3.8
+ * Requires PHP: 5.6
  * Tested up to: 4.9
  * Woo: 435833:ec0f55d8fa7c517dc1844f5c873a77da
  *

--- a/sensei-course-progress.php
+++ b/sensei-course-progress.php
@@ -15,7 +15,9 @@
  * @since 1.0.0
  */
 
-if ( ! defined( 'ABSPATH' ) ) exit;
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
 
 define( 'SENSEI_COURSE_PROGRESS_VERSION', '2.0.0-beta.1' );
 define( 'SENSEI_COURSE_PROGRESS_PLUGIN_FILE', __FILE__ );
@@ -23,20 +25,13 @@ define( 'SENSEI_COURSE_PROGRESS_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );
 
 require_once dirname( __FILE__ ) . '/includes/class-sensei-course-progress-dependency-checker.php';
 
-if ( ! Sensei_Course_Progress_Dependency_Checker::are_dependencies_met() ) {
+if ( ! Sensei_Course_Progress_Dependency_Checker::are_system_dependencies_met() ) {
 	return;
 }
 
-require_once( dirname( __FILE__ ) . '/includes/class-sensei-course-progress.php' );
+require_once dirname( __FILE__ ) . '/includes/class-sensei-course-progress.php';
 
-/**
- * Returns the main instance of Sensei_Course_Progress to prevent the need to use globals.
- *
- * @since  1.0.0
- * @return object Sensei_Course_Progress
- */
-function Sensei_Course_Progress() {
-	return Sensei_Course_Progress::instance();
-}
+// Load the plugin after all the other plugins have loaded.
+add_action( 'plugins_loaded', array( 'Sensei_Course_Progress', 'init' ), 5 );
 
-Sensei_Course_Progress();
+Sensei_Course_Progress::instance();


### PR DESCRIPTION
This brings over the work to check dependencies and load plugin after the other plugins have loaded. This simplifies our Sensei check and makes it work for non-standard install locations.

### Testing Instructions
- If activated, deactivate all versions of Sensei. 
- Remove `sensei-version` and `woothemes-sensei-version` options.
- If not active, activate this plugin on built version of this branch. Verify the Sensei dependency message shows on Plugins page and Dashboard page.
- Activate Sensei 1.12.x. Verify message disappears.
- Deactivate Sensei 1.12.x. Activate Sensei 2.x. Verify message is still gone.
- Deactivate Sensei 2.x and activate Sensei with WooCommerce Paid Courses. Verify message is still gone.

Test PHP version:
- Activate Sensei and version of this branch on PHP 5.2-5.5. Verify PHP version notice appears.

In addition:
- Make sure version is logged in options (`sensei_course_progress_version`) on activation even when Sensei isn't first activated.