### PR TITLE
Fix translations not loading

### DIFF
--- a/includes/class-sensei-course-progress-widget.php
+++ b/includes/class-sensei-course-progress-widget.php
@@ -248,7 +248,7 @@ class Sensei_Course_Progress_Widget extends WP_Widget {
 						if ( $new_module ) {
 							$module_title = $this->get_module_title_content( $new_module );
 						} else {
-							$module_title = esc_html( __( 'Other Lessons', 'woothemes-sensei' ) );
+							$module_title = esc_html( __( 'Other Lessons', 'sensei-course-progress' ) );
 						}
 
 						?>
@@ -316,10 +316,10 @@ class Sensei_Course_Progress_Widget extends WP_Widget {
 		?>
 				<p>
 					<input type="checkbox" class="checkbox" id="<?php echo esc_attr( $this->get_field_id('allmodules') ); ?>" name="<?php echo esc_attr( $this->get_field_name('allmodules') ); ?>"<?php checked( $instance['allmodules'], 'on' ); ?> />
-					<label for="<?php echo esc_attr( $this->get_field_id('allmodules') ); ?>"><?php esc_html_e( 'Display all Modules', 'woothemes-sensei' ); ?></label><br />
+					<label for="<?php echo esc_attr( $this->get_field_id('allmodules') ); ?>"><?php esc_html_e( 'Display all Modules', 'sensei-course-progress' ); ?></label><br />
 				</p>
 		<?php } else { ?>
-				<p><?php esc_html_e( 'There are no options for this widget.', 'woothemes-sensei' ); ?></p>
+				<p><?php esc_html_e( 'There are no options for this widget.', 'sensei-course-progress' ); ?></p>
 				<?php }
 	} // End form()
 

--- a/includes/class-sensei-course-progress.php
+++ b/includes/class-sensei-course-progress.php
@@ -126,7 +126,7 @@ class Sensei_Course_Progress {
 	 * @return void
 	 */
 	public function load_localisation () {
-		load_plugin_textdomain( 'sensei-course-progress' , false , dirname( SENSEI_COURSE_PROGRESS_PLUGIN_BASENAME ) . '/lang/' );
+		load_plugin_textdomain( 'sensei-course-progress' , false , dirname( SENSEI_COURSE_PROGRESS_PLUGIN_BASENAME ) . '/languages/' );
 	} // End load_localisation()
 
 	/**
@@ -141,7 +141,7 @@ class Sensei_Course_Progress {
 		$locale = apply_filters( 'plugin_locale' , get_locale() , $domain );
 
 		load_textdomain( $domain , WP_LANG_DIR . '/' . $domain . '/' . $domain . '-' . $locale . '.mo' );
-		load_plugin_textdomain( $domain , FALSE , dirname( SENSEI_COURSE_PROGRESS_PLUGIN_BASENAME ) . '/lang/' );
+		load_plugin_textdomain( $domain , FALSE , dirname( SENSEI_COURSE_PROGRESS_PLUGIN_BASENAME ) . '/languages/' );
 	} // End load_plugin_textdomain
 
 	/**


### PR DESCRIPTION
The translations were not loading because the plugin was looking in the `lang` folder, when in fact the folder is actually named `languages`. There were also some incorrect text domains which have been updated.

## Testing
1. In _Settings_ > _General_, change the _Site Language_ to Russian (i.e. Русский).
2. Go to _Appearance_ > _Widgets_.
3. Look for the _Sensei LMS - Course Progress_ widget.
4. Ensure the description is translated.
5. Add the widget to the sidebar.
6. Ensure the widget checkbox setting is translated.