### PR TITLE
Add readme.txt to build instead of README.md

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -23,7 +23,7 @@ function cssMinify() {
 }
 
 function docs() {
-	return src( [ 'changelog.txt', 'README.md' ] )
+	return src( [ 'changelog.txt', 'readme.txt' ] )
 		.pipe( dest( buildDir ) )
 }
 


### PR DESCRIPTION
We should add `readme.txt` to the build instead of `README.md`, as the `txt` version is needed on WordPress.org.

## Testing
Run `gulp package` and ensure that `readme.txt` is copied to the `build/sensei-course-progress` folder.