### PR TITLE
Make progress widget collapsible. #115

### DIFF
--- a/assets/css/frontend.scss
+++ b/assets/css/frontend.scss
@@ -14,9 +14,9 @@
 			}
 		}
 	}
+
 	.course-progress-lessons {
 		list-style: none;
-		clear: both;
 		#sidebar & {
 			margin: 0;
 		}
@@ -56,11 +56,6 @@
 				background: rgba(255,255,255,1);
 				text-decoration: none;
 			}
-			&:first-child {
-				a, span {
-					border-top: 1px solid rgba(0,0,0,0.1);
-				}
-			}
 			&.current span {
 				background: rgba(255,255,255,1);
 				color: rgba(0,0,0,0.5);
@@ -86,6 +81,12 @@
 	ul.course-progress-navigation {
 		background: #eee;
 		border-top: 1px solid #ddd;
+		display: flex;
+		flex-direction: row;
+		justify-content: flex-start;
+		align-items: center;
+		margin: 0;
+		padding: 0;
 		li {
 			width: 50%;
 			text-align: center;
@@ -114,7 +115,7 @@
 				}
 			}
 			&.prev {
-				float: left;
+				margin-right: auto;
 				a {
 					border-right: 1px solid #ddd;
 					&:before {
@@ -123,7 +124,7 @@
 				}
 			}
 			&.next {
-				float: right;
+				margin-left: auto;
 				a {
 					&:after {
 						content: "\f054";
@@ -132,4 +133,43 @@
 			}
 		}
 	}
+}
+
+details.course-progress-details {
+	summary {
+		outline: none;
+		&::marker, &::-webkit-details-marker {
+			content: "";
+			display: none;
+		}
+	}
+}
+
+details.course-progress-details {
+	.course-progress-summary {
+		height: 32px;
+		width: 100%;
+		display: flex;
+		justify-content: center;
+		align-items: center;
+		user-select: none;
+		text-decoration: underline;
+		&:hover {
+			cursor: pointer;
+			background: rgba(0,0,0,0.01);
+		}
+	}
+	.course-progress-collapse {
+		display: none;
+	}
+}
+
+details.course-progress-details[open] {
+	.course-progress-collapse {
+		display: block;
+	}
+	.course-progress-expand {
+		display: none;
+	}
+
 }

--- a/includes/class-sensei-course-progress-widget.php
+++ b/includes/class-sensei-course-progress-widget.php
@@ -210,6 +210,15 @@ class Sensei_Course_Progress_Widget extends WP_Widget {
 
 		<?php } ?>
 
+	<details class="course-progress-details" open>
+		<summary class="course-progress-summary">
+			<div class="course-progress-collapse">
+				<?php echo esc_html__( 'Collapse', 'sensei-course-progress' ); ?>
+			</div>
+			<div class="course-progress-expand">
+				<?php echo esc_html__( 'Expand', 'sensei-course-progress' ); ?>
+			</div>
+		</summary>
 		<ul class="course-progress-lessons">
 
 			<?php
@@ -272,6 +281,7 @@ class Sensei_Course_Progress_Widget extends WP_Widget {
 			<?php } ?>
 
 		</ul>
+	</details>
 
 		<?php echo wp_kses_post( $after_widget );
 	}


### PR DESCRIPTION
Fixes #115 

### Changes proposed in this Pull Request

- Implements a simple collapse functionality for Course Progress Widget. Uses HTML `details` element. Works alright and does not require JavaScript. However there are two concerns that needs attention from design perspective.
  - The collapse/expand happens without animation. It simply jumps up and down.
  - ~~The collapse/expand indicator with the next/previous lesson navigations look like a happy/sad face. 😄~~ (Changed to Expand/Collapse text. See in comments below)

### Testing instructions

- Enable Course Progress widget and navigate to any lesson page.
- Confirm the Course Progress widget can collapse/expand.

<!-- Add the following only if there are new/updated actions or filters. Please provide a brief description of what they do and any arguments they may take. Be sure to also add the "Hooks" label to this PR. -->
### New/Updated Hooks

- n/a

<!-- Add the following only if there is any code that is being deprecated. Please list the replacement function or hook that should be called instead, if applicable. Be sure to also add the "Deprecation" label to this PR. -->
### Deprecated Code

- n/a

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

https://user-images.githubusercontent.com/2578542/136911673-e2f9604f-f5e2-4996-bc04-07846fa40d44.mp4 
