### PR TITLE
Show Course Progress widget on the course page.

### DIFF
--- a/includes/class-sensei-course-progress-widget.php
+++ b/includes/class-sensei-course-progress-widget.php
@@ -48,12 +48,15 @@ class Sensei_Course_Progress_Widget extends WP_Widget {
 		}
 
 		// If not viewing a lesson/quiz, don't display the widget
-		if( ! ( is_singular( 'lesson' ) || is_singular( 'quiz' ) || is_tax( 'module' ) ) ) return;
+		if( ! ( is_singular( 'lesson' ) || is_singular( 'quiz' ) || is_singular( 'course' ) || is_tax( 'module' ) ) ) return;
 
 		extract( $args );
 
 		if ( is_singular('quiz') ) {
 			$current_lesson_id = absint( get_post_meta( $post->ID, '_quiz_lesson', true ) );
+		} elseif ( is_singular('course')) {
+			$course_lesson_ids = Sensei()->course->course_lessons( $post->ID, 'any', 'ids' );
+			$current_lesson_id = isset( $course_lesson_ids[0] ) ? $course_lesson_ids[0] : $post->ID;
 		} else {
 			$current_lesson_id = $post->ID;
 		}


### PR DESCRIPTION
Fixes #93 

### Changes proposed in this Pull Request

- Shows the Course Progress widget on the Course page. However it looks like we don't need it anymore with the new Course page layout. Let's discuss!

#### Needs Attention

- The Previous (lesson) button on the Course Progress widget is blank. Looks a bit confusing. See screenshot below.

### Testing instructions

- Create a course with some lessons in it.
- Visit the course page and confirm the Course Progress widget is shown.

<!-- Add the following only if there are new/updated actions or filters. Please provide a brief description of what they do and any arguments they may take. Be sure to also add the "Hooks" label to this PR. -->
### New/Updated Hooks

- n/a

<!-- Add the following only if there is any code that is being deprecated. Please list the replacement function or hook that should be called instead, if applicable. Be sure to also add the "Deprecation" label to this PR. -->
### Deprecated Code

- n/a

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

<img width="1774" alt="after" src="https://user-images.githubusercontent.com/2578542/136927303-36d4359e-b060-4e53-887c-c9361c447524.png">
